### PR TITLE
member, sgg, history entity/repository 생성 & repository test

### DIFF
--- a/src/main/java/com/kakaotech/back/dto/favourite/RegisterMemberTravelStylesDto.java
+++ b/src/main/java/com/kakaotech/back/dto/favourite/RegisterMemberTravelStylesDto.java
@@ -1,0 +1,20 @@
+package com.kakaotech.back.dto.favourite;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegisterMemberTravelStylesDto {
+    private String travelStyle1;
+    private String travelStyle2;
+    private String travelStyle3;
+    private String travelStyle4;
+    private String travelStyle5;
+    private String travelStyle6;
+    private String travelStyle7;
+    private String travelStyle8;
+}

--- a/src/main/java/com/kakaotech/back/entity/Favourite.java
+++ b/src/main/java/com/kakaotech/back/entity/Favourite.java
@@ -24,14 +24,14 @@ public class Favourite {
     //    TODO: Merge시 원본 Member로 변경해야함
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private TempMember member;
+    private Member member;
 
     @CreatedDate
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime registerAt;
 
     @Builder
-    public Favourite(Place place, LocalDateTime registerAt, TempMember member) {
+    public Favourite(Place place, LocalDateTime registerAt, Member member) {
         this.place = place;
         this.registerAt = registerAt;
         this.member = member;

--- a/src/main/java/com/kakaotech/back/entity/Favourite.java
+++ b/src/main/java/com/kakaotech/back/entity/Favourite.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@Builder
 public class Favourite {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,11 +29,4 @@ public class Favourite {
     @CreatedDate
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime registerAt;
-
-    @Builder
-    public Favourite(Place place, LocalDateTime registerAt, Member member) {
-        this.place = place;
-        this.registerAt = registerAt;
-        this.member = member;
-    }
 }

--- a/src/main/java/com/kakaotech/back/entity/Favourite.java
+++ b/src/main/java/com/kakaotech/back/entity/Favourite.java
@@ -21,7 +21,6 @@ public class Favourite {
     @JoinColumn(name = "place_id")
     private Place place;
 
-    //    TODO: Merge시 원본 Member로 변경해야함
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/kakaotech/back/entity/Gender.java
+++ b/src/main/java/com/kakaotech/back/entity/Gender.java
@@ -1,0 +1,16 @@
+package com.kakaotech.back.entity;
+
+public enum Gender {
+    MALE("Male"),
+    FEMALE("Female");
+
+    private final String displayName;
+
+    Gender(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/kakaotech/back/entity/History.java
+++ b/src/main/java/com/kakaotech/back/entity/History.java
@@ -26,6 +26,10 @@ public class History {
     @JoinColumn(name = "place_id")
     private Place place;
 
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     @CreatedDate
     @Column(name = "register_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime registerAt;

--- a/src/main/java/com/kakaotech/back/entity/History.java
+++ b/src/main/java/com/kakaotech/back/entity/History.java
@@ -1,0 +1,33 @@
+package com.kakaotech.back.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Builder
+public class History {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @CreatedDate
+    @Column(name = "register_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime registerAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/kakaotech/back/entity/History.java
+++ b/src/main/java/com/kakaotech/back/entity/History.java
@@ -22,6 +22,10 @@ public class History {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+
     @CreatedDate
     @Column(name = "register_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime registerAt;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -72,19 +72,19 @@ public class Member {
     @JoinColumn(name = "sgg_id")
     private SGG sgg;
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "visit_id")
     private List<Visit> visits;
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "favourite_id")
     private List<Favourite> favourites;
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private List<Review> reviews;
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "history_id")
     private List<History> histories;
 

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -74,16 +74,13 @@ public class Member {
     @JoinColumn(name = "sgg_id")
     private SGG sgg;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "visit_id")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Visit> visits;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "favourite_id")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Favourite> favourites;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Review> reviews;
 
     @OneToMany(fetch = FetchType.LAZY)

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -47,4 +47,36 @@ public class Member {
     private String travelStyle8;
     @CreatedDate
     private LocalDateTime registerAt;
+
+    public void SetTravelStyle1(String travelStyle1) {
+        this.travelStyle1 = travelStyle1;
+    }
+
+    public void SetTravelStyle2(String travelStyle2) {
+        this.travelStyle2 = travelStyle2;
+    }
+
+    public void SetTravelStyle3(String travelStyle3) {
+        this.travelStyle3 = travelStyle3;
+    }
+
+    public void SetTravelStyle4(String travelStyle4) {
+        this.travelStyle4 = travelStyle4;
+    }
+
+    public void SetTravelStyle5(String travelStyle5) {
+        this.travelStyle5 = travelStyle5;
+    }
+
+    public void SetTravelStyle6(String travelStyle6) {
+        this.travelStyle6 = travelStyle6;
+    }
+
+    public void SetTravelStyle7(String travelStyle7) {
+        this.travelStyle7 = travelStyle7;
+    }
+
+    public void SetTravelStyle8(String travelStyle8) {
+        this.travelStyle8 = travelStyle8;
+    }
 }

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -80,6 +80,10 @@ public class Member {
     @JoinColumn(name = "favourite_id")
     private List<Favourite> favourites;
 
+    @OneToMany
+    @JoinColumn(name = "review_id")
+    private List<Review> reviews;
+
     
 
     public void SetTravelStyle1(String travelStyle1) {

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -84,7 +84,9 @@ public class Member {
     @JoinColumn(name = "review_id")
     private List<Review> reviews;
 
-    
+    @OneToMany
+    @JoinColumn(name = "history_id")
+    private List<History> histories;
 
     public void SetTravelStyle1(String travelStyle1) {
         this.travelStyle1 = travelStyle1;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -26,6 +26,7 @@ public class Member {
     private String password;
 
     private String nickname;
+    
     private String gender;
 
     private Integer age;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -16,11 +16,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @Builder
-// TODO: merge 시 삭제
-public class TempMember {
+public class Member {
     @Id
     private String id;
-    @Column(name = "member_id")
+    @Column(name = "member_id", unique = true)
     private String memberId;
     private String password;
     private String nickname;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -19,33 +19,49 @@ import java.time.LocalDateTime;
 public class Member {
     @Id
     private String id;
+
     @Column(name = "member_id", unique = true)
     private String memberId;
+
     private String password;
+
     private String nickname;
     private String gender;
+
     private Integer age;
+
     @Column(name = "travel_like_sido")
     private String travelLikeSIDO;
+
     @Column(name = "travel_like_sgg")
     private String travelLikeSGG;
+
     @Column(name = "travel_style_1")
     private String travelStyle1;
+
     @Column(name = "travel_style_2")
     private String travelStyle2;
+
     @Column(name = "travel_style_3")
     private String travelStyle3;
+
     @Column(name = "travel_style_4")
     private String travelStyle4;
+
     @Column(name = "travel_style_5")
     private String travelStyle5;
+
     @Column(name = "travel_style_6")
     private String travelStyle6;
+
     @Column(name = "travel_style_7")
     private String travelStyle7;
+
     @Column(name = "travel_style_8")
     private String travelStyle8;
+
     @CreatedDate
+    @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime registerAt;
 
     public void SetTravelStyle1(String travelStyle1) {

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -29,7 +29,9 @@ public class Member {
     private String nickname;
 
     @NotBlank
-    private String gender;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
 
     @NotBlank
     private Integer age;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -1,9 +1,6 @@
 package com.kakaotech.back.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -69,6 +66,10 @@ public class Member {
     @CreatedDate
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime registerAt;
+
+    @OneToOne
+    @JoinColumn(name = "sgg_id")
+    private SGG sgg;
 
     public void SetTravelStyle1(String travelStyle1) {
         this.travelStyle1 = travelStyle1;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -86,36 +86,4 @@ public class Member {
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "history_id")
     private List<History> histories;
-
-    public void SetTravelStyle1(String travelStyle1) {
-        this.travelStyle1 = travelStyle1;
-    }
-
-    public void SetTravelStyle2(String travelStyle2) {
-        this.travelStyle2 = travelStyle2;
-    }
-
-    public void SetTravelStyle3(String travelStyle3) {
-        this.travelStyle3 = travelStyle3;
-    }
-
-    public void SetTravelStyle4(String travelStyle4) {
-        this.travelStyle4 = travelStyle4;
-    }
-
-    public void SetTravelStyle5(String travelStyle5) {
-        this.travelStyle5 = travelStyle5;
-    }
-
-    public void SetTravelStyle6(String travelStyle6) {
-        this.travelStyle6 = travelStyle6;
-    }
-
-    public void SetTravelStyle7(String travelStyle7) {
-        this.travelStyle7 = travelStyle7;
-    }
-
-    public void SetTravelStyle8(String travelStyle8) {
-        this.travelStyle8 = travelStyle8;
-    }
 }

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -70,6 +71,10 @@ public class Member {
     @OneToOne
     @JoinColumn(name = "sgg_id")
     private SGG sgg;
+
+    @OneToMany
+    @JoinColumn(name = "visit_id")
+    private List<Visit> visits;
 
     public void SetTravelStyle1(String travelStyle1) {
         this.travelStyle1 = travelStyle1;

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -76,6 +76,12 @@ public class Member {
     @JoinColumn(name = "visit_id")
     private List<Visit> visits;
 
+    @OneToMany
+    @JoinColumn(name = "favourite_id")
+    private List<Favourite> favourites;
+
+    
+
     public void SetTravelStyle1(String travelStyle1) {
         this.travelStyle1 = travelStyle1;
     }

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -83,7 +83,6 @@ public class Member {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Review> reviews;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "history_id")
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<History> histories;
 }

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -21,14 +22,18 @@ public class Member {
     private String id;
 
     @Column(name = "member_id", unique = true)
+    @NotBlank
     private String memberId;
 
+    @NotBlank
     private String password;
 
     private String nickname;
-    
+
+    @NotBlank
     private String gender;
 
+    @NotBlank
     private Integer age;
 
     @Column(name = "travel_like_sido")

--- a/src/main/java/com/kakaotech/back/entity/Review.java
+++ b/src/main/java/com/kakaotech/back/entity/Review.java
@@ -21,7 +21,7 @@ public class Review {
     //    TODO: Merge시 원본 Member로 변경해야함
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private TempMember member;
+    private Member member;
 
     @ManyToOne
     @JoinColumn(name = "place_id")
@@ -38,7 +38,7 @@ public class Review {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Review(TempMember member, Place place, String content, LocalDateTime registerAt, LocalDateTime updatedAt) {
+    public Review(Member member, Place place, String content, LocalDateTime registerAt, LocalDateTime updatedAt) {
         this.member = member;
         this.place = place;
         this.content = content;

--- a/src/main/java/com/kakaotech/back/entity/Review.java
+++ b/src/main/java/com/kakaotech/back/entity/Review.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@Builder
 public class Review {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,13 +37,4 @@ public class Review {
     @LastModifiedDate
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-
-    @Builder
-    public Review(Member member, Place place, String content, LocalDateTime registerAt, LocalDateTime updatedAt) {
-        this.member = member;
-        this.place = place;
-        this.content = content;
-        this.registerAt = registerAt;
-        this.updatedAt = updatedAt;
-    }
 }

--- a/src/main/java/com/kakaotech/back/entity/Review.java
+++ b/src/main/java/com/kakaotech/back/entity/Review.java
@@ -19,7 +19,6 @@ public class Review {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //    TODO: Merge시 원본 Member로 변경해야함
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/kakaotech/back/entity/SGG.java
+++ b/src/main/java/com/kakaotech/back/entity/SGG.java
@@ -13,7 +13,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "sgg")
 public class SGG {
 
     @Id

--- a/src/main/java/com/kakaotech/back/entity/SGG.java
+++ b/src/main/java/com/kakaotech/back/entity/SGG.java
@@ -3,8 +3,9 @@ package com.kakaotech.back.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.Max;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Entity
@@ -12,26 +13,28 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Table(name = "sgg")
 public class SGG {
+
     @Id
-    @Max(50)
+    @Size(max = 50)
     @NotNull
     private String id;
 
     @Column(name = "sido_code")
-    @Max(10)
+    @Size(max = 10)
     private String sidoCode;
 
     @Column(name = "sgg_code")
-    @Max(10)
+    @Size(max = 10)
     private String sggCode;
 
     @Column(name = "sido_name")
-    @Max(100)
+    @Size(max = 100)
     @NotNull
     private String sidoName;
 
     @Column(name = "sgg_name")
-    @Max(100)
+    @Size(max = 100)
     private String sggName;
 }

--- a/src/main/java/com/kakaotech/back/entity/SGG.java
+++ b/src/main/java/com/kakaotech/back/entity/SGG.java
@@ -1,0 +1,37 @@
+package com.kakaotech.back.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SGG {
+    @Id
+    @Max(50)
+    @NotNull
+    private String id;
+
+    @Column(name = "sido_code")
+    @Max(10)
+    private String sidoCode;
+
+    @Column(name = "sgg_code")
+    @Max(10)
+    private String sggCode;
+
+    @Column(name = "sido_name")
+    @Max(100)
+    @NotNull
+    private String sidoName;
+
+    @Column(name = "sgg_name")
+    @Max(100)
+    private String sggName;
+}

--- a/src/main/java/com/kakaotech/back/entity/Visit.java
+++ b/src/main/java/com/kakaotech/back/entity/Visit.java
@@ -19,7 +19,7 @@ public class Visit {
     //    TODO: Merge시 원본 Member로 변경해야함
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private TempMember member;
+    private Member member;
 
     @Column(name = "residence_time")
     private int residenceTime;
@@ -33,7 +33,7 @@ public class Visit {
     private int revisitIntention;
 
     @Builder
-    private Visit(Place place, TempMember member, int residenceTime, int visitTypeCode, String revisitYN, int rating, int revisitIntention) {
+    private Visit(Place place, Member member, int residenceTime, int visitTypeCode, String revisitYN, int rating, int revisitIntention) {
         this.place = place;
         this.member = member;
         this.residenceTime = residenceTime;

--- a/src/main/java/com/kakaotech/back/entity/Visit.java
+++ b/src/main/java/com/kakaotech/back/entity/Visit.java
@@ -7,6 +7,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class Visit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,15 +32,4 @@ public class Visit {
     private int rating;
     @Column(name = "revisit_intention")
     private int revisitIntention;
-
-    @Builder
-    private Visit(Place place, Member member, int residenceTime, int visitTypeCode, String revisitYN, int rating, int revisitIntention) {
-        this.place = place;
-        this.member = member;
-        this.residenceTime = residenceTime;
-        this.visitTypeCode = visitTypeCode;
-        this.revisitYN = revisitYN;
-        this.rating = rating;
-        this.revisitIntention = revisitIntention;
-    }
 }

--- a/src/main/java/com/kakaotech/back/entity/Visit.java
+++ b/src/main/java/com/kakaotech/back/entity/Visit.java
@@ -17,7 +17,6 @@ public class Visit {
     @JoinColumn(name = "place_id")
     private Place place;
 
-    //    TODO: Merge시 원본 Member로 변경해야함
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/kakaotech/back/repository/FavouriteRepository.java
+++ b/src/main/java/com/kakaotech/back/repository/FavouriteRepository.java
@@ -1,7 +1,7 @@
 package com.kakaotech.back.repository;
 
 import com.kakaotech.back.entity.Favourite;
-import com.kakaotech.back.entity.TempMember;
+import com.kakaotech.back.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 @Repository
 public interface FavouriteRepository extends JpaRepository<Favourite, Long> {
-    Optional<List<Favourite>> findByMember(TempMember member);
+    Optional<List<Favourite>> findByMember(Member member);
 }

--- a/src/main/java/com/kakaotech/back/repository/HistoryRepository.java
+++ b/src/main/java/com/kakaotech/back/repository/HistoryRepository.java
@@ -1,0 +1,9 @@
+package com.kakaotech.back.repository;
+
+import com.kakaotech.back.entity.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, Long> {
+}

--- a/src/main/java/com/kakaotech/back/repository/MemberRepository.java
+++ b/src/main/java/com/kakaotech/back/repository/MemberRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TempMemberRepository extends JpaRepository<Member, String>{
+public interface MemberRepository extends JpaRepository<Member, String>{
 }

--- a/src/main/java/com/kakaotech/back/repository/SGGRepository.java
+++ b/src/main/java/com/kakaotech/back/repository/SGGRepository.java
@@ -1,0 +1,9 @@
+package com.kakaotech.back.repository;
+
+import com.kakaotech.back.entity.SGG;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SGGRepository extends JpaRepository<SGG, String> {
+}

--- a/src/main/java/com/kakaotech/back/repository/TempMemberRepository.java
+++ b/src/main/java/com/kakaotech/back/repository/TempMemberRepository.java
@@ -1,9 +1,9 @@
 package com.kakaotech.back.repository;
 
-import com.kakaotech.back.entity.TempMember;
+import com.kakaotech.back.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TempMemberRepository extends JpaRepository<TempMember, String>{
+public interface TempMemberRepository extends JpaRepository<Member, String>{
 }

--- a/src/main/java/com/kakaotech/back/service/FavouriteService.java
+++ b/src/main/java/com/kakaotech/back/service/FavouriteService.java
@@ -7,7 +7,7 @@ import com.kakaotech.back.common.exception.PlaceException;
 import com.kakaotech.back.dto.favourite.RegisterFavouriteDto;
 import com.kakaotech.back.entity.Favourite;
 import com.kakaotech.back.entity.Place;
-import com.kakaotech.back.entity.TempMember;
+import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.repository.FavouriteRepository;
 import com.kakaotech.back.repository.PlaceRepository;
 import com.kakaotech.back.repository.TempMemberRepository;
@@ -28,7 +28,7 @@ public class FavouriteService {
 
     @Transactional(readOnly = true)
     public List<Favourite> getFavourites(String memberId) {
-        Optional<TempMember> member = memberRepository.findById(memberId);
+        Optional<Member> member = memberRepository.findById(memberId);
         if(member.isEmpty()) throw new MemberException(ErrorMessage.USER_NOT_FOUND);
 
         return favouriteRepository.findByMember(member.get()).get();
@@ -36,7 +36,7 @@ public class FavouriteService {
 
     @Transactional
     public Boolean registerFavourite(RegisterFavouriteDto dto) {
-        Optional<TempMember> member = memberRepository.findById(dto.getMemberId());
+        Optional<Member> member = memberRepository.findById(dto.getMemberId());
         // Member 찾기
         if (member.isEmpty()) {
             throw new MemberException(ErrorMessage.USER_NOT_FOUND);

--- a/src/main/java/com/kakaotech/back/service/FavouriteService.java
+++ b/src/main/java/com/kakaotech/back/service/FavouriteService.java
@@ -9,8 +9,8 @@ import com.kakaotech.back.entity.Favourite;
 import com.kakaotech.back.entity.Place;
 import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.repository.FavouriteRepository;
+import com.kakaotech.back.repository.MemberRepository;
 import com.kakaotech.back.repository.PlaceRepository;
-import com.kakaotech.back.repository.TempMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class FavouriteService {
     private final FavouriteRepository favouriteRepository;
-    private final TempMemberRepository memberRepository;
+    private final MemberRepository memberRepository;
     private final PlaceRepository placeRepository;
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/kakaotech/back/repository/HistoryRepositoryTest.java
+++ b/src/test/java/com/kakaotech/back/repository/HistoryRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.kakaotech.back.repository;
+
+import com.kakaotech.back.entity.History;
+import com.kakaotech.back.entity.Place;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class HistoryRepositoryTest {
+
+    @Autowired
+    private HistoryRepository historyRepository;
+    @Autowired
+    private PlaceRepository placeRepository;
+    private History history;
+    private Place place;
+
+    @BeforeEach
+    public void setUp() {
+        place = Place.builder()
+                .id("Sample Place")
+                .areaName("Sample Area")
+                .roadName("Sample Road")
+                .xCoord(123.45)
+                .yCoord(67.89)
+                .imageUrl("http://example.com/image.jpg")
+                .build();
+
+        place = placeRepository.save(place);
+
+        assertNotNull(place.getId()); // null test
+
+        history = History.builder()
+                .content("Sample content")
+                .place(place)
+                .build();
+    }
+
+    @Test
+    public void testSaveHistory() {
+        History savedHistory = historyRepository.save(history);
+        assertNotNull(savedHistory);
+        assertEquals("Sample content", savedHistory.getContent());
+        assertNotNull(savedHistory.getPlace());
+        assertEquals(place.getId(), savedHistory.getPlace().getId());
+    }
+
+    @Test
+    public void testFindHistoryById() {
+        History savedHistory = historyRepository.save(history);
+        History foundHistory = historyRepository.findById(savedHistory.getId()).orElse(null);
+        assertNotNull(foundHistory);
+        assertEquals("Sample content", foundHistory.getContent());
+        assertNotNull(foundHistory.getPlace());
+        assertEquals(place.getId(), foundHistory.getPlace().getId());
+    }
+}

--- a/src/test/java/com/kakaotech/back/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/kakaotech/back/repository/MemberRepositoryTest.java
@@ -1,14 +1,16 @@
 package com.kakaotech.back.repository;
 
 import com.kakaotech.back.entity.Gender;
+import com.kakaotech.back.entity.History;
 import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.entity.SGG;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -21,12 +23,21 @@ public class MemberRepositoryTest {
     private MemberRepository memberRepository;
     @Autowired
     private SGGRepository sggRepository;
+    @Autowired
+    private HistoryRepository historyRepository;
     private Member member;
+    private History history;
 
     @BeforeEach
     public void setUp() {
         SGG sgg = new SGG("sgg1", "sidoCode1", "sggCode1", "sidoName1", "sggName1");
         sggRepository.save(sgg);  // SGG 엔터티를 먼저 저장
+
+
+        history = History.builder()
+                .content("Sample content")
+                .build();
+        history = historyRepository.save(history);
 
         member = Member.builder()
                 .id("member1")
@@ -35,6 +46,7 @@ public class MemberRepositoryTest {
                 .nickname("nickname")
                 .gender(Gender.MALE)
                 .age(30)
+                .histories(List.of(history))
                 .sgg(sgg)
                 .build();
     }
@@ -52,5 +64,12 @@ public class MemberRepositoryTest {
         Member foundMember = memberRepository.findById("member1").orElse(null);
         assertNotNull(foundMember);
         assertEquals("mem001", foundMember.getMemberId());
+    }
+
+    @Test
+    public void testRelationshipMemberAndHistory() {
+        memberRepository.save(member);
+        Member foundMember = memberRepository.findById("member1").orElse(null);
+        assertEquals("Sample content", foundMember.getHistories().get(0).getContent());
     }
 }

--- a/src/test/java/com/kakaotech/back/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/kakaotech/back/repository/MemberRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.kakaotech.back.repository;
+
+import com.kakaotech.back.entity.Gender;
+import com.kakaotech.back.entity.Member;
+import com.kakaotech.back.entity.SGG;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private SGGRepository sggRepository;
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        SGG sgg = new SGG("sgg1", "sidoCode1", "sggCode1", "sidoName1", "sggName1");
+        sggRepository.save(sgg);  // SGG 엔터티를 먼저 저장
+
+        member = Member.builder()
+                .id("member1")
+                .memberId("mem001")
+                .password("password")
+                .nickname("nickname")
+                .gender(Gender.MALE)
+                .age(30)
+                .sgg(sgg)
+                .build();
+    }
+
+    @Test
+    public void testSaveMember() {
+        Member savedMember = memberRepository.save(member);
+        assertNotNull(savedMember);
+        assertEquals("member1", savedMember.getId());
+    }
+
+    @Test
+    public void testFindMemberById() {
+        memberRepository.save(member);
+        Member foundMember = memberRepository.findById("member1").orElse(null);
+        assertNotNull(foundMember);
+        assertEquals("mem001", foundMember.getMemberId());
+    }
+}

--- a/src/test/java/com/kakaotech/back/repository/SGGRepositoryTest.java
+++ b/src/test/java/com/kakaotech/back/repository/SGGRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.kakaotech.back.repository;
+
+import com.kakaotech.back.entity.SGG;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class SGGRepositoryTest {
+
+    @Autowired
+    private SGGRepository sggRepository;
+    private SGG sgg;
+
+    @BeforeEach
+    public void setUp() {
+        sgg = SGG.builder()
+                .id("sgg1")
+                .sidoCode("sidoCode1")
+                .sggCode("sggCode1")
+                .sidoName("sidoName1")
+                .sggName("sggName1")
+                .build();
+    }
+
+    @Test
+    public void testSaveSGG() {
+        SGG savedSGG = sggRepository.save(sgg);
+        assertNotNull(savedSGG);
+        assertEquals("sgg1", savedSGG.getId());
+    }
+
+    @Test
+    public void testFindSGGById() {
+        sggRepository.save(sgg);
+        SGG foundSGG = sggRepository.findById("sgg1").orElse(null);
+        assertNotNull(foundSGG);
+        assertEquals("sidoCode1", foundSGG.getSidoCode());
+    }
+}

--- a/src/test/java/com/kakaotech/back/service/FavouriteServiceTest.java
+++ b/src/test/java/com/kakaotech/back/service/FavouriteServiceTest.java
@@ -4,7 +4,7 @@ import com.kakaotech.back.common.exception.MemberException;
 import com.kakaotech.back.dto.favourite.RegisterFavouriteDto;
 import com.kakaotech.back.entity.Favourite;
 import com.kakaotech.back.entity.Place;
-import com.kakaotech.back.entity.TempMember;
+import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.repository.FavouriteRepository;
 import com.kakaotech.back.repository.PlaceRepository;
 import com.kakaotech.back.repository.TempMemberRepository;
@@ -37,13 +37,13 @@ public class FavouriteServiceTest {
     @InjectMocks
     private FavouriteService favouriteService;
 
-    private TempMember member;
+    private Member member;
     private Place place;
     private Favourite favourite;
 
     @BeforeEach
     void setUp() {
-        member = TempMember.builder()
+        member = Member.builder()
                 .id("MEMBERID")
                 .build();
         place = Place.builder()

--- a/src/test/java/com/kakaotech/back/service/FavouriteServiceTest.java
+++ b/src/test/java/com/kakaotech/back/service/FavouriteServiceTest.java
@@ -6,8 +6,8 @@ import com.kakaotech.back.entity.Favourite;
 import com.kakaotech.back.entity.Place;
 import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.repository.FavouriteRepository;
+import com.kakaotech.back.repository.MemberRepository;
 import com.kakaotech.back.repository.PlaceRepository;
-import com.kakaotech.back.repository.TempMemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ public class FavouriteServiceTest {
     private FavouriteRepository favouriteRepository;
 
     @Mock
-    private TempMemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Mock
     private PlaceRepository placeRepository;


### PR DESCRIPTION
### 주제

> 어떤 작업을 했는지 간단하게 작성합니다.

- `member, sgg, history` entity 생성
-  `member, sgg, history` repository 생성
-  repository test

### 세부 내용

> 코드/문서의 변경사항을 구체적으로 작성합니다.
> 여러 기능을 작업했을 경우 각 기능별로 작성합니다.
> 테스트인 경우 어떤 테스트를 했는지 설명합니다.
> UI 개발의 경우 스크린샷이 있다면 좋습니다.
> 형식을 꼭 지키지 않아도 됩니다.

1. member entity
&emsp; - `@OneToMany` Lazy Loading, 연관관계 주인(양방향인 경우만) 설정
&emsp; - travel style을 추가할 수 있도록 setter 코드 작성
&emsp; - gender의 경우 kakao 로그인 시 `female, male` 2개의 type만 지정해주기 때문에 enum 객체로 잘 못 기입되지 않도록 함. (`@Enumerated(EnumType.STRING)`은 보다 의미를 부여할 수 있도록 하기 위함.)
&emsp; - 회원가입시 꼭 기입해야 하는 값은 `@NotBlank`로 설정

2. SGG entity
&emsp; - AI hub에서 설정된 최대 값을 설정함. (혹여나 100길이의 name값이 10길이의  code로 잘 못들어가지 않도록. 최대한 방어하기 위함)

3. History entity
&emsp; - database에서 text의 경우 `@Column(columnDefinition = "TEXT")` 설정

4. Repository
&emsp; - 일단은 JPA에서 제공하는 기본 CURD만 사용하도록 JPA Repository 이용

5. Test 코드
&emsp; - 기본적으로 save, findByID만 테스트
&emsp; - Member의 경우 `@OneToMany`의 관계가 많기 때문에, History Entity와의 연관관계가 잘 설정되는지만 확인
