### PR TITLE
Feature/config s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Amazon SDK
+	implementation 'software.amazon.awssdk:s3:2.27.12'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakaotech/back/config/S3Config.java
+++ b/src/main/java/com/kakaotech/back/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.kakaotech.back.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${aws.access-key}")
+    String accessKey;
+
+    @Value("${aws.secret-key}")
+    String secretKey;
+
+    @Value("${aws.region}")
+    String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials
+                .create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .serviceConfiguration(S3Configuration.builder().build())
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/back/controller/PlaceController.java
+++ b/src/main/java/com/kakaotech/back/controller/PlaceController.java
@@ -1,12 +1,14 @@
 package com.kakaotech.back.controller;
 
 import com.kakaotech.back.dto.place.PlaceReqDto;
+import com.kakaotech.back.dto.place.PlaceResDto;
 import com.kakaotech.back.service.place.PlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -15,9 +17,8 @@ import java.util.Map;
 public class PlaceController {
     private final PlaceService placeService;
 
-    // TODO: S3 URL 응답
-    @PostMapping(value = "/image", produces = "image/*")
-    public ResponseEntity<byte[]> getPlaceImage(@RequestBody PlaceReqDto dto) {
-        return ResponseEntity.ok().contentType(MediaType.IMAGE_JPEG).body(placeService.getPlaceImage(dto.placeId()));
+    @PostMapping("/image")
+    public ResponseEntity<PlaceResDto> getPlaceImage(@RequestBody PlaceReqDto dto) {
+        return ResponseEntity.ok(placeService.getPlaceImage(dto.placeId()));
     }
 }

--- a/src/main/java/com/kakaotech/back/dto/place/PlaceResDto.java
+++ b/src/main/java/com/kakaotech/back/dto/place/PlaceResDto.java
@@ -1,4 +1,10 @@
 package com.kakaotech.back.dto.place;
 
-public class PlaceResDto {
+import lombok.Builder;
+
+@Builder
+public record PlaceResDto(
+        Long placeId,
+        byte[] image
+) {
 }

--- a/src/main/java/com/kakaotech/back/service/place/PlaceImageService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceImageService.java
@@ -1,11 +1,9 @@
 package com.kakaotech.back.service.place;
 
-import com.kakaotech.back.common.exception.GoogleApiException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -16,9 +14,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/kakaotech/back/service/place/PlaceImageService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceImageService.java
@@ -5,9 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -24,6 +28,27 @@ public class PlaceImageService {
 
     @Value("${aws.s3.bucket-name}")
     String bucketName;
+
+    // S3에 있는 이미지 파일 가져오기
+    public byte[] fetchImage(Long placeId) {
+        String keyName = "trippop-image/" + placeId + ".jpg";
+
+        try {
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(keyName)
+                    .build();
+
+            ResponseInputStream<GetObjectResponse> response = s3Client.getObject(request);
+            return response.readAllBytes();
+        } catch (S3Exception e) {
+            logger.error("FAILED TO FETCH IMAGE {}: {}", keyName, e.getMessage());
+        } catch (IOException e) {
+            logger.error("FAILED TO READ IMAGE {}: {}", keyName, e.getMessage());
+        }
+        // 에러 발생시 null 반환
+        return null;
+    }
 
     // S3에 업로드
     public void saveImage(Long placeId, byte[] imageData) {

--- a/src/main/java/com/kakaotech/back/service/place/PlaceImageService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceImageService.java
@@ -1,9 +1,15 @@
 package com.kakaotech.back.service.place;
 
 import com.kakaotech.back.common.exception.GoogleApiException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,18 +17,26 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @Service
+@RequiredArgsConstructor
 public class PlaceImageService {
+    private final S3Client s3Client;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    // TODO: DB에 저장
-    public void saveImage(Long placeId, byte[] imageData) {
+    @Value("${aws.s3.bucket-name}")
+    String bucketName;
 
-        Path path = Paths.get("src", "main", "resources", "image", placeId + ".jpg");
+    // S3에 업로드
+    public void saveImage(Long placeId, byte[] imageData) {
+        String keyName = "trippop-image/" + placeId + ".jpg";
         try {
-            Files.write(path, imageData);
-        } catch (IOException e) {
-            logger.error("FAILED TO SAVE IMAGE: {}", e.getMessage());
-            throw new GoogleApiException("구글 이미지 저장 실패");
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(keyName)
+                    .build();
+            s3Client.putObject(request, RequestBody.fromBytes(imageData));
+        } catch (S3Exception e) {
+            logger.error("FAILED TO UPLOAD IMAGE: {}", e.getMessage());
         }
+
     }
 }

--- a/src/main/java/com/kakaotech/back/service/place/PlaceService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceService.java
@@ -5,6 +5,8 @@ import com.kakaotech.back.vo.PlaceCoordVO;
 import com.kakaotech.back.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -16,12 +18,19 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
     private final GooglePlaceService googlePlaceService;
     private final PlaceImageService imageService;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public byte[] getPlaceImage(Long placeId) {
+        // S3에 존재하는지 확인
+        byte[] imageData = imageService.fetchImage(placeId);
+        if (imageData != null) return imageData;
+
+        // Google Place API
         String googlePlaceId = getGooglePlaceId(placeId);
         String photoName = getPlacePhotoName(googlePlaceId);
 
-        byte[] imageData = googlePlaceService.getPlaceImage(photoName);
+        // 응답받은 이미지 파일을 S3에 업로드 후 반환
+        imageData = googlePlaceService.getPlaceImage(photoName);
         imageService.saveImage(placeId, imageData);
 
         return imageData;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,12 @@ spring:
 google:
   maps:
     api-key: ${GOOGLE_API_KEY}
+aws:
+  region: ${AWS_REGION}
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
+  s3:
+    bucket-name: ${AWS_BUCKET_NAME}
 ---
 # local
 server:
@@ -28,7 +34,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
 ---
 # dev
 server:


### PR DESCRIPTION
### 주제

> 어떤 작업을 했는지 간단하게 작성합니다.

장소 이미지 응답 개선 - 이미지 캐싱

### 세부 내용
![image](https://github.com/user-attachments/assets/b807ff96-fad8-4a97-be7d-964e9b4c9bb6)

#8 지난 PR의 이미지 응답 flow를 개선했습니다.
**파란선**이 추가된 flow입니다. (S3에 업로드 추가)

#### 1. S3 설정
aws sdk를 이용해 S3 연결 설정
#### 2. dto
place id와 해당 이미지로 구성.
추후, place 관련 정보를 추가할 예정입니다.
이미지는 `byte[]` 타입이지만 실제로 응답해줄때는 base64로 인코딩되어 응답됩니다.
#### 3. 이미지 응답 로직 변경
이제부터 S3에 해당 place의 이미지가 존재하는지 확인하고,
없으면 google api에 요청하여 s3에 이미지 업로드 및 응답,
있다면 즉시 s3의 이미지를 응답해줍니다.
