### PR TITLE
Feature/travel style

### DIFF
--- a/src/main/java/com/kakaotech/back/controller/MemberController.java
+++ b/src/main/java/com/kakaotech/back/controller/MemberController.java
@@ -2,8 +2,10 @@ package com.kakaotech.back.controller;
 
 import com.kakaotech.back.dto.member.MemberRequestDto;
 import com.kakaotech.back.dto.member.MemberResponseDto;
+import com.kakaotech.back.dto.member.MemberSurveyDto;
 import com.kakaotech.back.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,5 +28,11 @@ public class MemberController {
         MemberResponseDto memberResponseDto = memberService.saveMember(memberRequestDto);
         URI location = URI.create("/member/" + memberResponseDto.getId());
         return ResponseEntity.created(location).body(memberResponseDto);
+    }
+
+    // TODO: SecurityContext의 인증정보의 id로 대체
+    @PatchMapping("/survey/{memberId}")
+    public ResponseEntity<MemberSurveyDto> updateTravelStyle(@PathVariable String memberId, @RequestBody MemberSurveyDto memberSurveyDto) {
+        return ResponseEntity.ok(memberService.updateSurvey(memberId, memberSurveyDto));
     }
 }

--- a/src/main/java/com/kakaotech/back/controller/PlaceController.java
+++ b/src/main/java/com/kakaotech/back/controller/PlaceController.java
@@ -1,15 +1,13 @@
 package com.kakaotech.back.controller;
 
+import com.kakaotech.back.dto.place.PlaceListReqDto;
+import com.kakaotech.back.dto.place.PlaceListResDto;
 import com.kakaotech.back.dto.place.PlaceReqDto;
 import com.kakaotech.back.dto.place.PlaceResDto;
 import com.kakaotech.back.service.place.PlaceService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +18,10 @@ public class PlaceController {
     @PostMapping("/image")
     public ResponseEntity<PlaceResDto> getPlaceImage(@RequestBody PlaceReqDto dto) {
         return ResponseEntity.ok(placeService.getPlaceImage(dto.placeId()));
+    }
+
+    @PostMapping("/recommended")
+    public ResponseEntity<PlaceListResDto> getRecommendedImages(@RequestBody PlaceListReqDto dto){
+        return ResponseEntity.ok(placeService.getRecommendedImages(dto));
     }
 }

--- a/src/main/java/com/kakaotech/back/controller/PlaceController.java
+++ b/src/main/java/com/kakaotech/back/controller/PlaceController.java
@@ -16,12 +16,12 @@ public class PlaceController {
     private final PlaceService placeService;
 
     @PostMapping("/image")
-    public ResponseEntity<PlaceResDto> getPlaceImage(@RequestBody PlaceReqDto dto) {
-        return ResponseEntity.ok(placeService.getPlaceImage(dto.placeId()));
+    public ResponseEntity<PlaceResDto> getPlaceImage(@RequestBody PlaceReqDto placeReqDto) {
+        return ResponseEntity.ok(placeService.getPlaceImage(placeReqDto.placeId()));
     }
 
     @PostMapping("/recommended")
-    public ResponseEntity<PlaceListResDto> getRecommendedImages(@RequestBody PlaceListReqDto dto){
-        return ResponseEntity.ok(placeService.getRecommendedImages(dto));
+    public ResponseEntity<PlaceListResDto> getRecommendedImages(@RequestBody PlaceListReqDto placeListReqDto){
+        return ResponseEntity.ok(placeService.getRecommendedImages(placeListReqDto));
     }
 }

--- a/src/main/java/com/kakaotech/back/dto/member/MemberSurveyDto.java
+++ b/src/main/java/com/kakaotech/back/dto/member/MemberSurveyDto.java
@@ -1,0 +1,29 @@
+package com.kakaotech.back.dto.member;
+
+import com.kakaotech.back.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberSurveyDto(
+        Integer travelStyle1,
+        Integer travelStyle2,
+        Integer travelStyle3,
+        Integer travelStyle4,
+        Integer travelStyle5,
+        Integer travelStyle6,
+        Integer travelStyle7,
+        Integer travelStyle8
+) {
+    public static MemberSurveyDto from(Member member) {
+        return MemberSurveyDto.builder()
+                .travelStyle1(member.getTravelStyle1())
+                .travelStyle2(member.getTravelStyle2())
+                .travelStyle3(member.getTravelStyle3())
+                .travelStyle4(member.getTravelStyle4())
+                .travelStyle5(member.getTravelStyle5())
+                .travelStyle6(member.getTravelStyle6())
+                .travelStyle7(member.getTravelStyle7())
+                .travelStyle8(member.getTravelStyle8())
+                .build();
+    }
+}

--- a/src/main/java/com/kakaotech/back/dto/place/PlaceListReqDto.java
+++ b/src/main/java/com/kakaotech/back/dto/place/PlaceListReqDto.java
@@ -11,6 +11,6 @@ import java.util.List;
 public record PlaceListReqDto(
         @NotEmpty(message = "EMPTY ARRAY")
         @Size(max = 10)
-        List<@Min(value = 1, message = "SHOULD BE ABOVE THAN 0") Long> placeId
+        List<@Min(value = 1, message = "SHOULD BE ABOVE THAN 0") Long> places
 ) {
 }

--- a/src/main/java/com/kakaotech/back/dto/place/PlaceListReqDto.java
+++ b/src/main/java/com/kakaotech/back/dto/place/PlaceListReqDto.java
@@ -1,0 +1,16 @@
+package com.kakaotech.back.dto.place;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PlaceListReqDto(
+        @NotEmpty(message = "EMPTY ARRAY")
+        @Size(max = 10)
+        List<@Min(value = 1, message = "SHOULD BE ABOVE THAN 0") Long> placeId
+) {
+}

--- a/src/main/java/com/kakaotech/back/dto/place/PlaceListResDto.java
+++ b/src/main/java/com/kakaotech/back/dto/place/PlaceListResDto.java
@@ -1,0 +1,11 @@
+package com.kakaotech.back.dto.place;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PlaceListResDto(
+    List<PlaceResDto> places
+){
+}

--- a/src/main/java/com/kakaotech/back/entity/Member.java
+++ b/src/main/java/com/kakaotech/back/entity/Member.java
@@ -1,5 +1,6 @@
 package com.kakaotech.back.entity;
 
+import com.kakaotech.back.dto.member.MemberSurveyDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -43,28 +44,28 @@ public class Member {
     private SGG travelLikeSGG;
 
     @Column(name = "travel_style_1")
-    private String travelStyle1;
+    private Integer travelStyle1;
 
     @Column(name = "travel_style_2")
-    private String travelStyle2;
+    private Integer travelStyle2;
 
     @Column(name = "travel_style_3")
-    private String travelStyle3;
+    private Integer travelStyle3;
 
     @Column(name = "travel_style_4")
-    private String travelStyle4;
+    private Integer travelStyle4;
 
     @Column(name = "travel_style_5")
-    private String travelStyle5;
+    private Integer travelStyle5;
 
     @Column(name = "travel_style_6")
-    private String travelStyle6;
+    private Integer travelStyle6;
 
     @Column(name = "travel_style_7")
-    private String travelStyle7;
+    private Integer travelStyle7;
 
     @Column(name = "travel_style_8")
-    private String travelStyle8;
+    private Integer travelStyle8;
 
     @CreatedDate
     @Column(columnDefinition = "TIMESTAMP")
@@ -87,5 +88,16 @@ public class Member {
         if (this.id == null) {
             this.id = UUID.randomUUID().toString();
         }
+    }
+
+    public void updateStyle(MemberSurveyDto dto){
+        this.travelStyle1 = dto.travelStyle1();
+        this.travelStyle2 = dto.travelStyle2();
+        this.travelStyle3 = dto.travelStyle3();
+        this.travelStyle4 = dto.travelStyle4();
+        this.travelStyle5 = dto.travelStyle5();
+        this.travelStyle6 = dto.travelStyle6();
+        this.travelStyle7 = dto.travelStyle7();
+        this.travelStyle8 = dto.travelStyle8();
     }
 }

--- a/src/main/java/com/kakaotech/back/service/MemberService.java
+++ b/src/main/java/com/kakaotech/back/service/MemberService.java
@@ -1,8 +1,10 @@
 package com.kakaotech.back.service;
 
 import com.kakaotech.back.common.exception.AlreadyExistsException;
+import com.kakaotech.back.common.exception.NotFoundException;
 import com.kakaotech.back.dto.member.MemberResponseDto;
 import com.kakaotech.back.dto.member.MemberRequestDto;
+import com.kakaotech.back.dto.member.MemberSurveyDto;
 import com.kakaotech.back.entity.Gender;
 import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.repository.MemberRepository;
@@ -26,7 +28,7 @@ public class MemberService {
     @Transactional
     public MemberResponseDto saveMember(MemberRequestDto memberRequestDto) {
         if (memberRepository.existsByMemberId(memberRequestDto.getMemberId())) {
-            throw new AlreadyExistsException(memberRequestDto.getMemberId()+"는 이미 존재하는 ID 입니다.");
+            throw new AlreadyExistsException(memberRequestDto.getMemberId() + "는 이미 존재하는 ID 입니다.");
         }
 
         Member member = Member.builder()
@@ -46,6 +48,15 @@ public class MemberService {
                 .build();
 
         return responseDto;
+    }
+
+    @Transactional
+    public MemberSurveyDto updateSurvey(String id, MemberSurveyDto dto) {
+        Member retrievedMember = memberRepository.findById(id).orElseThrow(
+                () -> new NotFoundException("USER NOT FOUND: " + id)
+        );
+        retrievedMember.updateStyle(dto);
+        return MemberSurveyDto.from(retrievedMember);
     }
 
 }

--- a/src/main/java/com/kakaotech/back/service/place/GooglePlaceService.java
+++ b/src/main/java/com/kakaotech/back/service/place/GooglePlaceService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
@@ -60,10 +61,12 @@ public class GooglePlaceService {
     public byte[] getPlaceImage(String photoName) {
         String url = GOOGLE_API_URL_PREFIX + photoName + "/media?maxHeightPx=600&maxWidthPx=600&key=" + apiKey;
         try {
-            return restClient.get()
+            byte[] image = restClient.get()
                     .uri(url)
                     .retrieve()
                     .body(byte[].class);
+            if (image == null) throw new GoogleApiException("GOOGLE IMAGE 비정상 응답");
+            return image;
         } catch (HttpClientErrorException e) {
             logger.error("FAILED TO GET IMAGE: {}", e.getResponseBodyAsString());
             throw new GoogleApiException("GOOGLE IMAGE 획득 실패");
@@ -75,7 +78,7 @@ public class GooglePlaceService {
         return ((Map<String, Object>) ((List<Map<String, Object>>) placeDetails.get("photos")).getFirst()).get("name").toString();
     }
 
-    public String extractPlaceId(Map<String, Object> placeDetails){
+    public String extractPlaceId(Map<String, Object> placeDetails) {
         logger.info("PLACE INFO: {}", placeDetails);
         String origin = ((Map<String, Object>) ((List<Map<String, Object>>) placeDetails.get("places")).getFirst()).get("name").toString();
         return origin.split("/")[1];

--- a/src/main/java/com/kakaotech/back/service/place/PlaceService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceService.java
@@ -3,7 +3,6 @@ package com.kakaotech.back.service.place;
 import com.kakaotech.back.common.exception.NotFoundException;
 import com.kakaotech.back.dto.place.PlaceListReqDto;
 import com.kakaotech.back.dto.place.PlaceListResDto;
-import com.kakaotech.back.dto.place.PlaceReqDto;
 import com.kakaotech.back.dto.place.PlaceResDto;
 import com.kakaotech.back.vo.PlaceCoordVO;
 import com.kakaotech.back.repository.PlaceRepository;

--- a/src/main/java/com/kakaotech/back/service/place/PlaceService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceService.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -26,8 +27,7 @@ public class PlaceService {
     private final PlaceImageService imageService;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public PlaceResDto getPlaceImage(PlaceReqDto dto) {
-        Long placeId = dto.placeId();
+    public PlaceResDto getPlaceImage(Long placeId) {
         // S3에 존재하는지 확인
         byte[] imageData = imageService.fetchImage(placeId);
         if (imageData != null) return PlaceResDto.builder().placeId(placeId).image(imageData).build();
@@ -43,7 +43,8 @@ public class PlaceService {
     }
 
     public PlaceListResDto getRecommendedImages(PlaceListReqDto dto) {
-        return PlaceListResDto.builder().build();
+        List<PlaceResDto> recommended = dto.places().parallelStream().map(this::getPlaceImage).toList();
+        return PlaceListResDto.builder().places(recommended).build();
     }
 
     private PlaceCoordVO getCoordinate(Long placeId) {

--- a/src/main/java/com/kakaotech/back/service/place/PlaceService.java
+++ b/src/main/java/com/kakaotech/back/service/place/PlaceService.java
@@ -1,6 +1,9 @@
 package com.kakaotech.back.service.place;
 
 import com.kakaotech.back.common.exception.NotFoundException;
+import com.kakaotech.back.dto.place.PlaceListReqDto;
+import com.kakaotech.back.dto.place.PlaceListResDto;
+import com.kakaotech.back.dto.place.PlaceReqDto;
 import com.kakaotech.back.dto.place.PlaceResDto;
 import com.kakaotech.back.vo.PlaceCoordVO;
 import com.kakaotech.back.repository.PlaceRepository;
@@ -11,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.Map;
 
 @Service
@@ -24,7 +26,8 @@ public class PlaceService {
     private final PlaceImageService imageService;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public PlaceResDto getPlaceImage(Long placeId) {
+    public PlaceResDto getPlaceImage(PlaceReqDto dto) {
+        Long placeId = dto.placeId();
         // S3에 존재하는지 확인
         byte[] imageData = imageService.fetchImage(placeId);
         if (imageData != null) return PlaceResDto.builder().placeId(placeId).image(imageData).build();
@@ -37,6 +40,10 @@ public class PlaceService {
         imageData = googlePlaceService.getPlaceImage(photoName);
         imageService.saveImage(placeId, imageData);
         return PlaceResDto.builder().placeId(placeId).image(imageData).build();
+    }
+
+    public PlaceListResDto getRecommendedImages(PlaceListReqDto dto) {
+        return PlaceListResDto.builder().build();
     }
 
     private PlaceCoordVO getCoordinate(Long placeId) {

--- a/src/test/java/com/kakaotech/back/controller/MemberControllerTest.java
+++ b/src/test/java/com/kakaotech/back/controller/MemberControllerTest.java
@@ -1,0 +1,56 @@
+package com.kakaotech.back.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaotech.back.dto.member.MemberSurveyDto;
+import com.kakaotech.back.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = MemberController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+public class MemberControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("여행 성향 변경")
+    void testPatchTravelStyle() throws Exception {
+        // Given
+        String memberId = "testId";
+        MemberSurveyDto request = MemberSurveyDto.builder()
+                .travelStyle1(1)
+                .travelStyle2(2)
+                .build();
+        MemberSurveyDto response = MemberSurveyDto.builder()
+                .travelStyle1(3)
+                .travelStyle2(4)
+                .build();
+
+        // When
+        when(memberService.updateSurvey(eq(memberId), eq(request))).thenReturn(response);
+
+        // Then
+        mockMvc.perform(patch("/member/survey/{memberId}", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.travelStyle1").value(response.travelStyle1()))
+                .andExpect(jsonPath("$.travelStyle2").value(response.travelStyle2()));
+    }
+}

--- a/src/test/java/com/kakaotech/back/service/MemberServiceTest.java
+++ b/src/test/java/com/kakaotech/back/service/MemberServiceTest.java
@@ -153,3 +153,58 @@ class MemberServiceTest {
         verify(memberRepository, times(1)).save(any(Member.class));
     }
 }
+
+package com.kakaotech.back.service;
+
+import com.kakaotech.back.dto.member.MemberSurveyDto;
+import com.kakaotech.back.entity.Member;
+import com.kakaotech.back.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    Member member;
+
+    @BeforeEach
+    void setup() {
+        member = Member.builder()
+                .id("a123456")
+                .age(30)
+                .travelStyle1(1)
+                .build();
+    }
+
+    @Test
+    @DisplayName("여행 성향 변경")
+    void testUpdateTravelStyle() {
+        // Given
+        MemberSurveyDto request = MemberSurveyDto.builder().travelStyle1(7).build();
+
+        // When
+        when(memberRepository.findById(anyString())).thenReturn(Optional.of(member));
+        MemberSurveyDto response = memberService.updateSurvey(member.getId(), request);
+
+        assertEquals(response.travelStyle1(), request.travelStyle1());
+    }
+}

--- a/src/test/java/com/kakaotech/back/service/MemberServiceTest.java
+++ b/src/test/java/com/kakaotech/back/service/MemberServiceTest.java
@@ -3,29 +3,33 @@ package com.kakaotech.back.service;
 import com.kakaotech.back.common.exception.AlreadyExistsException;
 import com.kakaotech.back.dto.member.MemberRequestDto;
 import com.kakaotech.back.dto.member.MemberResponseDto;
+import com.kakaotech.back.dto.member.MemberSurveyDto;
 import com.kakaotech.back.entity.Gender;
 import com.kakaotech.back.entity.Member;
 import com.kakaotech.back.repository.MemberRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
-
     @Mock
     private MemberRepository memberRepository;
 
@@ -34,11 +38,6 @@ class MemberServiceTest {
 
     @InjectMocks
     private MemberService memberService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     @DisplayName("멤버를 등록할 때, 멤버가 이미 존재하는 경우 예외")
@@ -152,53 +151,17 @@ class MemberServiceTest {
         verify(memberRepository, times(2)).existsByMemberId("duplicateId");
         verify(memberRepository, times(1)).save(any(Member.class));
     }
-}
 
-package com.kakaotech.back.service;
-
-import com.kakaotech.back.dto.member.MemberSurveyDto;
-import com.kakaotech.back.entity.Member;
-import com.kakaotech.back.repository.MemberRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-@ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
-    @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
-    private PasswordEncoder passwordEncoder;
-
-    @InjectMocks
-    private MemberService memberService;
-
-    Member member;
-
-    @BeforeEach
-    void setup() {
-        member = Member.builder()
-                .id("a123456")
-                .age(30)
-                .travelStyle1(1)
-                .build();
-    }
 
     @Test
     @DisplayName("여행 성향 변경")
     void testUpdateTravelStyle() {
         // Given
+        Member member = Member.builder()
+                .id("a123456")
+                .age(30)
+                .travelStyle1(1)
+                .build();
         MemberSurveyDto request = MemberSurveyDto.builder().travelStyle1(7).build();
 
         // When


### PR DESCRIPTION
### 주제

- 추천 여행지 및 사용자 여행 성향 변경 API 제작

### 세부 내용

> 코드/문서의 변경사항을 구체적으로 작성합니다.
> 여러 기능을 작업했을 경우 각 기능별로 작성합니다.
> 테스트인 경우 어떤 테스트를 했는지 설명합니다.
> UI 개발의 경우 스크린샷이 있다면 좋습니다.
> 형식을 꼭 지키지 않아도 됩니다.

### 엔티티
원래 `String` 타입이었던 travelStyleN을 `Integer`로 변경했습니다.
csv 파일은 문자열로 돼있었지만 숫자 형식이 맞다고 판단해 변경해주었습니다.

### 여행지 추천
`placeId` 배열에 대해 `parellelStream`으로 병렬적으로 이미지를 fetch하여 응답
이때, 이미지를 비정상적으로 수신하면 예외 발생

### 여행 성향 변경
-`survey/{memberId}` 형식으로 만들었지만, 추후 jwt 로그인 기능이 적용되면 `memberId`를 제거하고 Security Contenxt의 인증 정보를 활용할 생각입니다.

+ 여행지 및 여행 성향 API에 대한 테스트 진행